### PR TITLE
Merge new paint filtering logic to main.

### DIFF
--- a/bptf-autopricer.js
+++ b/bptf-autopricer.js
@@ -208,18 +208,16 @@ function handleEvent(e) {
                     return;
                 }
 
-                // Filter out painted items
-                if (listingItemObject.attributes) {
-                    // Loop through each attribute of the item, and check if any o each is a paint
-                    for (const attribute of listingItemObject.attributes) {
-                        // Check if value exists
-                        if (attribute.value) {
-                            if (Object.values(blockedAttributes).includes(attribute.value) &&
-                                !Object.keys(blockedAttributes).includes(response_item.name)) {
-                                return;  // Skip this listing. Listing is for a painted item.
-                            }
-                        }
-                    }
+                // Filter out painted items.
+                if (listingItemObject.attributes && listingItemObject.attributes.some(attribute => {
+                    return typeof attribute === 'object' && // Ensure the attribute is an object.
+                        attribute.float_value &&  // Ensure the attribute has a float_value.
+                        // Check if the float_value is in the blockedAttributes object.
+                        Object.values(blockedAttributes).map(String).includes(String(attribute.float_value)) &&
+                        // Ensure the name of the item doesn't include any of the keys in the blockedAttributes object.
+                        !Object.keys(blockedAttributes).some(key => name.includes(key));
+                })) {
+                    return;  // Skip this listing. Listing is for a painted item.
                 }
 
                 // Create a currencies object that contains only metal and keys.
@@ -354,13 +352,16 @@ const insertListings = async (unformattedListings, sku, name) => {
             // The item object where paint and stuff is stored.
             const listingItemObject = listing.item;
 
-            if (listingItemObject.attributes) {
-                for (const attribute of listingItemObject.attributes) {
-                    if (attribute.value && Object.values(blockedAttributes).includes(attribute.value) &&
-                        !Object.keys(blockedAttributes).includes(name)) {
-                        continue;  // Skip this listing. Listing is for a painted item.
-                    }
-                }
+            // Filter out painted items.
+            if (listingItemObject.attributes && listingItemObject.attributes.some(attribute => {
+                return typeof attribute === 'object' && // Ensure the attribute is an object.
+                    attribute.float_value &&  // Ensure the attribute has a float_value.
+                    // Check if the float_value is in the blockedAttributes object.
+                    Object.values(blockedAttributes).map(String).includes(String(attribute.float_value)) &&
+                    // Ensure the name of the item doesn't include any of the keys in the blockedAttributes object.
+                    !Object.keys(blockedAttributes).some(key => name.includes(key));
+            })) {
+                continue;  // Skip this listing. Listing is for a painted item.
             }
 
             // If userAgent field is not present, continue.

--- a/bptf-autopricer.js
+++ b/bptf-autopricer.js
@@ -351,6 +351,18 @@ const insertListings = async (unformattedListings, sku, name) => {
                 continue;
             }
 
+            // The item object where paint and stuff is stored.
+            const listingItemObject = listing.item;
+
+            if (listingItemObject.attributes) {
+                for (const attribute of listingItemObject.attributes) {
+                    if (attribute.value && Object.values(blockedAttributes).includes(attribute.value) &&
+                        !Object.keys(blockedAttributes).includes(name)) {
+                        return;  // Skip this listing. Listing is for a painted item.
+                    }
+                }
+            }
+
             // If userAgent field is not present, continue.
             // This indicates that the listing was not created by a bot.
             if (!listing.userAgent) {

--- a/bptf-autopricer.js
+++ b/bptf-autopricer.js
@@ -358,7 +358,7 @@ const insertListings = async (unformattedListings, sku, name) => {
                 for (const attribute of listingItemObject.attributes) {
                     if (attribute.value && Object.values(blockedAttributes).includes(attribute.value) &&
                         !Object.keys(blockedAttributes).includes(name)) {
-                        return;  // Skip this listing. Listing is for a painted item.
+                        continue;  // Skip this listing. Listing is for a painted item.
                     }
                 }
             }

--- a/config.json
+++ b/config.json
@@ -59,5 +59,37 @@
         "horseshoes/rotten orange",
         "headless horse",
         "pumpkin bombs"
-    ]
+    ],
+    "blockedAttributes": {
+        "Indubitably Green": 7511618,
+        "Zepheniah's Greed": 4345659,
+        "Noble Hatter's Violet": 5322826,
+        "Color No. 216-190-216": 14204632,
+        "A Deep Commitment to Purple": 8208497,
+        "Mann Co. Orange": 13595446,
+        "Muskelmannbraun": 10843461,
+        "Peculiarly Drab Tincture": 12955537,
+        "Radigan Conagher Brown": 6901050,
+        "Ye Olde Rustic Colour": 8154199,
+        "Australium Gold": 15185211,
+        "Aged Moustache Grey": 8289918,
+        "An Extraordinary Abundance of Tinge": 15132390,
+        "A Distinctive Lack of Hue": 1315860,
+        "Team Spirit": 12073019,
+        "Pink as Hell": 16738740,
+        "A Color Similar to Slate": 3100495,
+        "Drably Olive": 8421376,
+        "The Bitter Taste of Defeat and Lime": 3329330,
+        "The Color of a Gentlemann's Business Pants": 15787660,
+        "Dark Salmon Injustice": 15308410,
+        "Operator's Overalls": 4732984,
+        "Waterlogged Lab Coat": 11049612,
+        "Balaclavas Are Forever": 3874595,
+        "An Air of Debonair": 6637376,
+        "The Value of Teamwork": 8400928,
+        "Cream Spirit": 12807213,
+        "A Mann's Mint": 12377523,
+        "After Eight": 2960676,
+        "Legacy Paint": 5801378
+    }
 }


### PR DESCRIPTION
This new logic adds a step to filtering listings. Wherein the attributes of the listing are checked (if they exist) to see if they contain a float_value associated with a paint. Listings including such an attribute will be excluded from the pricing calculations as they tend to have different prices to the base item.

Thank you [purplebarber](https://github.com/purplebarber) for working on this.