### PR TITLE
Incorrect mean calculation in bptf-autopricer.js

### DIFF
--- a/bptf-autopricer.js
+++ b/bptf-autopricer.js
@@ -634,8 +634,9 @@ const filterOutliers = listingsArray => {
     // trusted steamids (when applicable).
     var filteredMean = 0;
     for (var i = 0; i <= 2; i++) {
-        filteredMean = +Methods.toMetal(filteredListings[i].currencies, keyobj.metal);
+        filteredMean += +Methods.toMetal(filteredListings[i].currencies, keyobj.metal);
     }
+    filteredMean /= 3;
 
     // Validate the mean.
     if (!filteredMean || isNaN(filteredMean) || filteredMean === 0) {


### PR DESCRIPTION
Mean calc overwrites with each loop resulting in only the 3rd buy listing being used and being treated as the mean incorrectly